### PR TITLE
Add: SSG and Dynamic page

### DIFF
--- a/src/app/dynamic/photos/[photoId]/page.tsx
+++ b/src/app/dynamic/photos/[photoId]/page.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+type Props = {
+  params: { photoId: string };
+};
+
+export default async function Page({ params: { photoId } }: Props) {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/photos/${photoId}`);
+  const data = await response.json();
+
+  return (
+    <div className="max-w-sm rounded overflow-hidden shadow-lg mx-auto">
+      <Image src={data.url} alt="Sunset in the mountains" width={600} height={200} />
+      <div className="px-6 py-4">
+        <div className="font-bold text-xl mb-2">{data.title}</div>
+        <p className="text-gray-700 text-base">
+          リクエスト毎に動的生成されるページです。
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/ssg-on-build/photos/[photoId]/page.tsx
+++ b/src/app/ssg-on-build/photos/[photoId]/page.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+
+type Props = {
+  params: { photoId: string };
+};
+
+export function generateStaticParams() {
+  return [{ photoId: '1' }, { photoId: '2' }, { photoId: '3' }]
+}
+
+export default async function Page({ params: { photoId } }: Props) {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/photos/${photoId}`);
+  const data = await response.json();
+
+  return (
+    <div className="max-w-sm rounded overflow-hidden shadow-lg mx-auto">
+      <Image src={data.url} alt="Sunset in the mountains" width={600} height={200} />
+      <div className="px-6 py-4">
+        <div className="font-bold text-xl mb-2">{data.title}</div>
+        <p className="text-gray-700 text-base">
+          ビルド時に静的生成されるページです。
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/ssg-on-request/photos/[photoId]/page.tsx
+++ b/src/app/ssg-on-request/photos/[photoId]/page.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+
+type Props = {
+  params: { photoId: string };
+};
+
+export function generateStaticParams() {
+  // リクエスト時生成に限定する場合は空配列を返す
+  return [];
+}
+
+export default async function Page({ params: { photoId } }: Props) {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/photos/${photoId}`);
+  const data = await response.json();
+
+  return (
+    <div className="max-w-sm rounded overflow-hidden shadow-lg mx-auto">
+      <Image src={data.url} alt="Sunset in the mountains" width={600} height={200} />
+      <div className="px-6 py-4">
+        <div className="font-bold text-xl mb-2">{data.title}</div>
+        <p className="text-gray-700 text-base">
+          リクエスト時にサーバーサイドでキャッシュされるページです。
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Static, SSG, Dynamic pageの比較まとめ

### ビルド結果
```
npm run build

Route (app)                              Size     First Load JS
┌ ○ /                                    182 B          92.2 kB
├ ○ /_not-found                          875 B          87.7 kB
├ ƒ /dynamic/photos/[photoId]            181 B          92.2 kB
├ ● /ssg-on-build/photos/[photoId]       181 B          92.2 kB
├   ├ /ssg-on-build/photos/1
├   ├ /ssg-on-build/photos/2
├   └ /ssg-on-build/photos/3
└ ● /ssg-on-request/photos/[photoId]     182 B          92.2 kB
+ First Load JS shared by all            86.9 kB
  ├ chunks/23-3032740b29323cf3.js        31.4 kB
  ├ chunks/fd9d1056-2821b0f0cabcd8bd.js  53.7 kB
  └ other shared chunks (total)          1.85 kB


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses getStaticProps)
ƒ  (Dynamic)  server-rendered on demand
```